### PR TITLE
Minor performance optimizations.

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -105,3 +105,7 @@ fast_weighted_sample <- function(size, probs) {
     .Call(`_malariasimulation_fast_weighted_sample`, size, probs)
 }
 
+double_variable_mean_cpp <- function(variable) {
+    .Call(`_malariasimulation_double_variable_mean_cpp`, variable)
+}
+

--- a/R/render.R
+++ b/R/render.R
@@ -112,7 +112,7 @@ create_variable_mean_renderer_process <- function(
     for (i in seq_along(variables)) {
       renderer$render(
         paste0(names[[i]], '_mean'),
-        mean(variables[[i]]$get_values()),
+        double_variable_mean(variables[[i]]),
         timestep
       )
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -88,3 +88,8 @@ RandomState <- R6::R6Class(
     }
   )
 )
+
+double_variable_mean <- function(v) {
+  stopifnot(inherits(v , "DoubleVariable"))
+  double_variable_mean_cpp(v$.variable)
+}

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -37,7 +37,7 @@ std::vector<size_t> Random::sample(size_t n, size_t size, bool replacement) {
 
 void Random::prop_sample_bucket(
         size_t size,
-        std::vector<double> probs,
+        const std::vector<double>& probs,
         int* result
     ) {
     auto n = probs.size();

--- a/src/Random.h
+++ b/src/Random.h
@@ -22,7 +22,7 @@ public:
     virtual std::vector<size_t> sample(size_t, size_t, bool) = 0;
     virtual void prop_sample_bucket(
         size_t size,
-        std::vector<double> probs,
+        const std::vector<double>& probs,
         int* result
     ) = 0;
     virtual void seed(size_t) = 0;
@@ -50,7 +50,7 @@ public:
     // method.
     virtual void prop_sample_bucket(
         size_t,
-        std::vector<double>,
+        const std::vector<double>&,
         int*
     );
     virtual ~Random() = default;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -347,6 +347,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// double_variable_mean_cpp
+double double_variable_mean_cpp(Rcpp::XPtr<DoubleVariable> variable);
+RcppExport SEXP _malariasimulation_double_variable_mean_cpp(SEXP variableSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<DoubleVariable> >::type variable(variableSEXP);
+    rcpp_result_gen = Rcpp::wrap(double_variable_mean_cpp(variable));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 RcppExport SEXP run_testthat_tests(void);
 
@@ -377,6 +388,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_malariasimulation_bernoulli_multi_p_cpp", (DL_FUNC) &_malariasimulation_bernoulli_multi_p_cpp, 1},
     {"_malariasimulation_bitset_index_cpp", (DL_FUNC) &_malariasimulation_bitset_index_cpp, 2},
     {"_malariasimulation_fast_weighted_sample", (DL_FUNC) &_malariasimulation_fast_weighted_sample, 2},
+    {"_malariasimulation_double_variable_mean_cpp", (DL_FUNC) &_malariasimulation_double_variable_mean_cpp, 1},
     {"run_testthat_tests", (DL_FUNC) &run_testthat_tests, 0},
     {NULL, NULL, 0}
 };

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -57,3 +57,16 @@ Rcpp::IntegerVector fast_weighted_sample(
     values = values + 1;
     return values;
 }
+
+//[[Rcpp::export]]
+double double_variable_mean_cpp(
+    Rcpp::XPtr<DoubleVariable> variable
+    ) {
+    if (variable->size() == 0) {
+        return R_NaN;
+    } else {
+        const std::vector<double>& values = variable->get_values();
+        double sum = std::accumulate(values.begin(), values.end(), 0.0);
+        return sum / values.size();
+    }
+}


### PR DESCRIPTION
- Compute variables' mean in C++ rather than R when rendering, avoiding an unnecessary copy.
- Remove a copy from `prop_sample_bucket` by using a const reference.